### PR TITLE
Don't ask users to use context

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,51 +69,99 @@ Don't forget to include the stylesheet in your page:
 
 1. Use `ref` in **parent component**:
 
-    ```javascript
-    class Parent extends React.Component {
-        componentDidMount() {
-            const { scrollbar } = this.refs.child;
-        }
-
-        render() {
-            return (
-                <Scrollbar ref="child">
-                    your content...
-                </Scrollbar>
-            );
-        }
-    }
-    ```
-
-2. Use `Context` in **child component**:
-
-    ```javascript
-    class Child extends React.Component {
-        static contextTypes = {
-            getScrollbar: React.PropTypes.func
-        };
-
-        componentDidMount() {
-            this.context.getScrollbar((scrollbar) => {
-                // ...
-            });
-        }
-
-        render() {
-            return <div> this is child component. </div>;
-        }
+```javascript
+class Parent extends React.Component {
+    componentDidMount() {
+        const { scrollbar } = this.refs.child;
     }
 
-    class App extends React.Component {
-        render(){
-            return (
-                <Scrollbar>
-                    <Child />
-                </Scrollbar>
-            );
-        }
+    render() {
+        return (
+            <Scrollbar ref="child">
+                your content...
+            </Scrollbar>
+        );
     }
-    ```
+}
+```
+
+2. Directly get `scrollbar` instance in a **child component**:
+
+```javascript
+// A.js
+import React from 'react';
+import { getScrollbar } from 'react-smooth-scrollbar';
+class A extends React.Component {
+    componentDidMount() {
+        this.props.getScrollbar((scrollbar) => {
+            // ...
+        });
+    }
+    render() {
+        return <div> this is child component. </div>;
+    }
+}
+export default getScrollbar()(A);
+
+// B.js
+import React from 'react';
+import B from 'A.js';
+export default class App extends React.Component {
+    render(){
+        return (
+            <div><A /></div>
+        );
+    }
+}
+
+// root.js
+import React from 'react';
+import Scrollbar from 'react-smooth-scrollbar';
+import B from 'B.js';
+class Root extends React.Component {
+    render() {
+        return (
+            <Scrollbar>
+                <B />
+            </Scrollbar>
+        );
+    }
+}
+```
+
+Or you can use decorators in a more simple way.
+
+```javascript
+// A.js
+import React from 'react';
+import { getScrollbar } from 'react-smooth-scrollbar';
+@getScrollbar()
+export default class A extends React.Component {
+    componentDidMount() {
+        this.props.getScrollbar((scrollbar) => {
+            // ...
+        });
+    }
+    render() {
+        return <div> this is child component. </div>;
+    }
+}
+
+// Also, if you want to modify the prop name:
+
+// A.js
+@getScrollbar(getScrollbar => ({customName: getScrollbar}))
+export default class A extends React.Component {
+    componentDidMount() {
+        this.props.customName((scrollbar) => {
+            // ...
+        });
+    }
+    render() {
+        return <div> this is child component. </div>;
+    }
+}
+```
 
 
 ## APIs

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-eslint": "^4.1.6",
     "babel-loader": "^6.2.1",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",

--- a/src/react-smooth-scrollbar.js
+++ b/src/react-smooth-scrollbar.js
@@ -106,3 +106,29 @@ export default class Scrollbar extends React.Component {
         );
     }
 }
+
+const getScrollbar = (mapScrollbarToProps = getScrollbar => ({ getScrollbar })) => WrappedComponent => {
+    const wrappedComponentName = WrappedComponent.displayName
+        || WrappedComponent.name
+        || 'Component';
+    const displayName = `getScrollbarFor${wrappedComponentName}`;
+
+    return class extends React.Component {
+        static displayName = displayName
+
+        static contextTypes = {
+            getScrollbar: PropTypes.func
+        };
+
+        render() {
+            return (
+                <WrappedComponent
+                    {...this.props}
+                    {...mapScrollbarToProps(this.context.getScrollbar)}
+                />
+            );
+        }
+    };
+};
+
+export { getScrollbar };

--- a/test/main.js
+++ b/test/main.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Scrollbar from '../src/react-smooth-scrollbar.js';
+import Scrollbar, { getScrollbar } from '../src/react-smooth-scrollbar.js';
 
 class Content extends React.Component {
     render() {
@@ -13,11 +13,8 @@ class Content extends React.Component {
     }
 }
 
+@getScrollbar()
 class InfiniteScroll extends React.Component {
-    static contextTypes = {
-        getScrollbar: React.PropTypes.func
-    };
-
     constructor(...args) {
         super(...args);
 
@@ -28,13 +25,13 @@ class InfiniteScroll extends React.Component {
     }
 
     componentDidMount() {
-        this.context.getScrollbar((scrollbar) => {
+        this.props.getScrollbar((scrollbar) => {
             scrollbar.infiniteScroll(::this.loadData);
         });
     }
 
     componentDidUpdate() {
-        this.context.getScrollbar((scrollbar) => {
+        this.props.getScrollbar((scrollbar) => {
             scrollbar.update();
         });
     }

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -11,7 +11,8 @@ module.exports = {
             exclude: /(node_modules|bower_components)/,
             loader: 'babel-loader',
             query: {
-                presets: ['es2015', 'stage-0', 'react']
+                presets: ['es2015', 'stage-0', 'react'],
+                plugins: ['transform-decorators-legacy']
             }
         }]
     }

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -31,6 +31,7 @@ module.exports = {
                 presets: ['es2015', 'stage-0', 'react'],
                 plugins: [
                     'add-module-exports',
+                    'transform-decorators-legacy'
                 ]
             }
         }]


### PR DESCRIPTION
It's better not to ask users to use context directly, use `High Order Component` instead.

See this [tweet](https://twitter.com/dan_abramov/status/749715530454622208) from *Dan Abramov*.

![hoc](https://cloud.githubusercontent.com/assets/15059605/23025394/caab19c8-f498-11e6-832f-8516720312f9.jpeg)

