### PR TITLE
update to react 15.5, proptypes replaced with standalone version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
     "gulp-babel": "^6.1.2",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.5.1",
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7",
+    "prop-types": "^15.5.8",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
     "webpack-stream": "^3.1.0"
   },
   "dependencies": {

--- a/src/react-smooth-scrollbar.js
+++ b/src/react-smooth-scrollbar.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import SmoothScrollbar from 'smooth-scrollbar';
 
 export default class Scrollbar extends React.Component {


### PR DESCRIPTION
Fixed the following warning.

Using the standalone proptypes package

> warning.js? Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.